### PR TITLE
Conda switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,9 @@ MAKEFLAGS = w
 #
 SUBDIRS =
 #
-# This is a list of directories that make should copy to $INSTALL_DIR.
-# If a Makefile is present in these directories, 'make install' will be
-# called on them.  Otherwise it will just be a plain copy.
+# Directory that will contain the shell scripts that "boot" the DESI environment.
 #
-INSTALLDIRS =
+SOFTWARE = /global/project/projectdirs/desi/software
 #
 # This is a message to make that these targets are 'actions' not files.
 #
@@ -42,9 +40,8 @@ all :
 # 'all' is a dependency of 'install'.
 #
 install : all
-	@ if test -d /project/projectdirs/desi/software/modules; then \
-		/bin/cp -v -f $(WORKING_DIR)/etc/desi_environment.* \
-		/project/projectdirs/desi/software/modules; fi
+	@ if test -d $(SOFTWARE); then \
+		/bin/cp -v -f $(WORKING_DIR)/etc/desi_environment.* $(SOFTWARE); fi
 #
 # GNU make pre-defines $(RM).  The - in front of $(RM) causes make to
 # ignore any errors produced by $(RM).

--- a/etc/desi_environment.csh
+++ b/etc/desi_environment.csh
@@ -6,10 +6,9 @@
 #
 if ( `basename ${SHELL}` == "csh" || `basename ${SHELL}` == "tcsh" ) then
     if ( "${NERSC_HOST}" == "edison" || "${NERSC_HOST}" == "cori" ) then
-        source /project/projectdirs/cmb/modules/hpcports_NERSC.csh
-        hpcports gnu
+        module use /global/common/${NERSC_HOST}/contrib/desi/modulefiles
     else
-        echo "HPCPorts is not supported on ${NERSC_HOST}!"
+        echo "DESI conda environment is not supported on ${NERSC_HOST}!"
     endif
     if ( -d /project/projectdirs/desi/software/modules/${NERSC_HOST} ) then
         module use /project/projectdirs/desi/software/modules/${NERSC_HOST}

--- a/etc/desi_environment.csh
+++ b/etc/desi_environment.csh
@@ -7,6 +7,8 @@
 if ( `basename ${SHELL}` == "csh" || `basename ${SHELL}` == "tcsh" ) then
     if ( "${NERSC_HOST}" == "edison" || "${NERSC_HOST}" == "cori" ) then
         module use /global/common/${NERSC_HOST}/contrib/desi/modulefiles
+    else if ( "${NERSC_HOST}" == "datatran" || "${NERSC_HOST}" == "scigate" ) then
+        echo
     else
         echo "DESI conda environment is not supported on ${NERSC_HOST}!"
     endif

--- a/etc/desi_environment.csh
+++ b/etc/desi_environment.csh
@@ -8,20 +8,14 @@ if ( `basename ${SHELL}` == "csh" || `basename ${SHELL}` == "tcsh" ) then
     if ( "${NERSC_HOST}" == "edison" || "${NERSC_HOST}" == "cori" ) then
         module use /global/common/${NERSC_HOST}/contrib/desi/modulefiles
     else if ( "${NERSC_HOST}" == "datatran" || "${NERSC_HOST}" == "scigate" ) then
-        # Do nothing, successfully.
-        :
+        module use /global/project/projectdirs/desi/software/${NERSC_HOST}/modulefiles
     else
-        echo "DESI conda environment is not supported on ${NERSC_HOST}!"
+        echo "DESI+Anaconda environment is not supported on ${NERSC_HOST}!"
     endif
-    if ( -d /project/projectdirs/desi/software/modules/${NERSC_HOST} ) then
-        module use /project/projectdirs/desi/software/modules/${NERSC_HOST}
-        if ( $# > 0 ) then
-            module load desimodules/$1
-        else
-            module load desimodules
-        endif
+    if ( $# > 0 ) then
+        module load desimodules/$1
     else
-        echo "Could not find DESI modules for ${NERSC_HOST}!"
+        module load desimodules
     endif
 else
     echo "You are not sourcing the correct file for your shell!"

--- a/etc/desi_environment.csh
+++ b/etc/desi_environment.csh
@@ -8,7 +8,8 @@ if ( `basename ${SHELL}` == "csh" || `basename ${SHELL}` == "tcsh" ) then
     if ( "${NERSC_HOST}" == "edison" || "${NERSC_HOST}" == "cori" ) then
         module use /global/common/${NERSC_HOST}/contrib/desi/modulefiles
     else if ( "${NERSC_HOST}" == "datatran" || "${NERSC_HOST}" == "scigate" ) then
-        echo
+        # Do nothing, successfully.
+        :
     else
         echo "DESI conda environment is not supported on ${NERSC_HOST}!"
     endif

--- a/etc/desi_environment.sh
+++ b/etc/desi_environment.sh
@@ -7,6 +7,8 @@
 if [[ $(basename ${SHELL}) == "bash" || $(basename ${SHELL}) == "sh" ]]; then
     if [[ "${NERSC_HOST}" == "edison" || "${NERSC_HOST}" == "cori" ]]; then
         module use /global/common/${NERSC_HOST}/contrib/desi/modulefiles
+    elif [[ "${NERSC_HOST}" == "datatran" || "${NERSC_HOST}" == "scigate" ]]; then
+        echo
     else
         echo "DESI conda environment is not supported on ${NERSC_HOST}!"
     fi

--- a/etc/desi_environment.sh
+++ b/etc/desi_environment.sh
@@ -8,7 +8,8 @@ if [[ $(basename ${SHELL}) == "bash" || $(basename ${SHELL}) == "sh" ]]; then
     if [[ "${NERSC_HOST}" == "edison" || "${NERSC_HOST}" == "cori" ]]; then
         module use /global/common/${NERSC_HOST}/contrib/desi/modulefiles
     elif [[ "${NERSC_HOST}" == "datatran" || "${NERSC_HOST}" == "scigate" ]]; then
-        echo
+        # Do nothing, successfully.
+        :
     else
         echo "DESI conda environment is not supported on ${NERSC_HOST}!"
     fi

--- a/etc/desi_environment.sh
+++ b/etc/desi_environment.sh
@@ -8,20 +8,14 @@ if [[ $(basename ${SHELL}) == "bash" || $(basename ${SHELL}) == "sh" ]]; then
     if [[ "${NERSC_HOST}" == "edison" || "${NERSC_HOST}" == "cori" ]]; then
         module use /global/common/${NERSC_HOST}/contrib/desi/modulefiles
     elif [[ "${NERSC_HOST}" == "datatran" || "${NERSC_HOST}" == "scigate" ]]; then
-        # Do nothing, successfully.
-        :
+        module use /global/project/projectdirs/desi/software/${NERSC_HOST}/modulefiles
     else
-        echo "DESI conda environment is not supported on ${NERSC_HOST}!"
+        echo "DESI+Anaconda environment is not supported on ${NERSC_HOST}!"
     fi
-    if [[ -d /project/projectdirs/desi/software/modules/${NERSC_HOST} ]]; then
-        module use /project/projectdirs/desi/software/modules/${NERSC_HOST}
-        if [[ $# > 0 ]]; then
-            module load desimodules/$1
-        else
-            module load desimodules
-        fi
+    if [[ $# > 0 ]]; then
+        module load desimodules/$1
     else
-        echo "Could not find DESI modules for ${NERSC_HOST}!"
+        module load desimodules
     fi
 else
     echo "You are not sourcing the correct file for your shell!"

--- a/etc/desi_environment.sh
+++ b/etc/desi_environment.sh
@@ -6,10 +6,9 @@
 #
 if [[ $(basename ${SHELL}) == "bash" || $(basename ${SHELL}) == "sh" ]]; then
     if [[ "${NERSC_HOST}" == "edison" || "${NERSC_HOST}" == "cori" ]]; then
-        source /project/projectdirs/cmb/modules/hpcports_NERSC.sh
-        hpcports gnu
+        module use /global/common/${NERSC_HOST}/contrib/desi/modulefiles
     else
-        echo "HPCPorts is not supported on ${NERSC_HOST}!"
+        echo "DESI conda environment is not supported on ${NERSC_HOST}!"
     fi
     if [[ -d /project/projectdirs/desi/software/modules/${NERSC_HOST} ]]; then
         module use /project/projectdirs/desi/software/modules/${NERSC_HOST}

--- a/etc/desimodules.module
+++ b/etc/desimodules.module
@@ -52,6 +52,12 @@ if {{ [info exists env(NERSC_HOST)] }} {{
     }} elseif {{ $env(NERSC_HOST) == "cori" }} {{
         set checkpre True
         module load desi-conda/2.7-20160829
+    }} elseif {{ $env(NERSC_HOST) == "datatran" }} {{
+        set checkpre True
+        module load desi-conda/2.7-20160906
+    }} elseif {{ $env(NERSC_HOST) == "scigate" }} {{
+        set checkpre True
+        module load desi-conda/2.7-201600906
     }} else {{
         set checkpre False
     }}

--- a/etc/desimodules.module
+++ b/etc/desimodules.module
@@ -46,26 +46,9 @@ module-whatis "Sets up $product/$version in your environment."
 # They only exist on edison and cori for now.
 #
 if {{ [info exists env(NERSC_HOST)] }} {{
-    if {{ $env(NERSC_HOST) == "edison" }} {{
-        set checkpre True
-        module load desi-conda/2.7-20160829
-    }} elseif {{ $env(NERSC_HOST) == "cori" }} {{
-        set checkpre True
-        module load desi-conda/2.7-20160829
-    }} elseif {{ $env(NERSC_HOST) == "datatran" }} {{
-        set checkpre True
-        module load desi-conda/2.7-20160906
-    }} elseif {{ $env(NERSC_HOST) == "scigate" }} {{
-        set checkpre True
-        module load desi-conda/2.7-201600906
-    }} else {{
-        set checkpre False
-    }}
-    if {{ $checkpre == "True" }} {{
-        prereq desi-conda
-    }}
+    module load desi-conda/3.5-20160913
+    prereq desi-conda
 }}
-
 #
 # DESI specific modules
 #
@@ -86,11 +69,11 @@ module load desimodel/0.4.5
 # will need to set the DESI_PRODUCT_ROOT environment variable
 #
 if {{[info exists env(DESI_PRODUCT_ROOT)]}} {{
-    set PRODUCT_ROOT $env(DESI_PRODUCT_ROOT)
+    set code_root $env(DESI_PRODUCT_ROOT)/code
 }} else {{
-    set PRODUCT_ROOT /project/projectdirs/desi/software/$env(NERSC_HOST)
+    set code_root {product_root}
 }}
-set PRODUCT_DIR $PRODUCT_ROOT/$product/$version
+set PRODUCT_DIR $code_root/$product/$version
 #
 # This line creates an environment variable pointing to the install
 # directory of your product.

--- a/etc/desimodules.module
+++ b/etc/desimodules.module
@@ -25,7 +25,7 @@ proc ModulesHelp {{ }} {{
 # prevents multiple versions from being loaded simultaneously.  Do not
 # change it.
 #
-set product desimodules
+set product {name}
 set version {version}
 conflict $product
 #
@@ -50,15 +50,22 @@ if {{ [info exists env(NERSC_HOST)] }} {{
     prereq desi-conda
 }}
 #
-# DESI specific modules
+# DESI-specific modules
 #
-module load desiutil
+module load desiutil/1.8.0
 prereq desiutil
 
-module load desitree
+module load desitree/0.3.0
 prereq desitree
 
+module load specter/0.6.0
 module load desimodel/0.4.5
+# module load specex
+module load desitarget/0.6.1
+module load specsim/v0.5
+module load desisim/0.14.0
+module load redmonster/master
+module load desispec/0.10.0
 
 #
 # ENVIRONMENT SECTION
@@ -84,9 +91,11 @@ setenv [string toupper $product] $PRODUCT_DIR
 # template product layout.  These will be set or commented as needed by the
 # desiInstall script.
 #
-## prepend-path PATH $PRODUCT_DIR/bin
-## prepend-path PYTHONPATH $PRODUCT_DIR/py
-## prepend-path LD_LIBRARY_PATH $PRODUCT_DIR/lib
+{needs_bin}prepend-path PATH $PRODUCT_DIR/bin
+{needs_python}prepend-path PYTHONPATH $PRODUCT_DIR/lib/{pyversion}/site-packages
+{needs_trunk_py}prepend-path PYTHONPATH $PRODUCT_DIR{trunk_py_dir}
+{needs_ld_lib}prepend-path LD_LIBRARY_PATH $PRODUCT_DIR/lib
+{needs_idl}prepend-path IDL_PATH +$PRODUCT_DIR/pro
 #
 # Add any non-standard Module code below this point.
 #

--- a/etc/desimodules.module
+++ b/etc/desimodules.module
@@ -60,7 +60,7 @@ prereq desitree
 
 module load specter/0.6.0
 module load desimodel/0.4.5
-# module load specex
+module load specex/0.4.0
 module load desitarget/0.6.1
 module load specsim/v0.5
 module load desisim/0.14.0

--- a/etc/desimodules.module
+++ b/etc/desimodules.module
@@ -48,33 +48,15 @@ module-whatis "Sets up $product/$version in your environment."
 if {{ [info exists env(NERSC_HOST)] }} {{
     if {{ $env(NERSC_HOST) == "edison" }} {{
         set checkpre True
-        module load astropy-hpcp/1.2.1_5fc56de5-9.0
-        module load scipy-hpcp/0.17.0_261d2fd3-9.0
-        module load matplotlib-hpcp/1.4.3_8d60f685-9.0
-        module load ipython-hpcp/3.0.0_655a190b-9.0
-        module load yaml-hpcp/a1ed8f02_a1ed8f02-9.0
-        module load fitsio-hpcp/d1fb9f2_c0563e28-9.0
-        module load requests-hpcp/2.8.1_b292912c-9.0
+        module load desi-conda/2.7-20160829
     }} elseif {{ $env(NERSC_HOST) == "cori" }} {{
         set checkpre True
-        module load astropy-hpcp/1.2.1_1f2b05e2-4.0
-        module load scipy-hpcp/0.17.0_fc9cd1dc-4.0
-        module load matplotlib-hpcp/1.4.3_f7d8d04a-4.0
-        module load ipython-hpcp/3.0.0_69f8e7b5-4.0
-        module load yaml-hpcp/6c68d4d8_6c68d4d8-4.0
-        module load fitsio-hpcp/d1fb9f2_9aff5bc6-4.0
-        module load requests-hpcp/2.8.1_8c18c9a4-4.0
+        module load desi-conda/2.7-20160829
     }} else {{
         set checkpre False
     }}
     if {{ $checkpre == "True" }} {{
-        prereq astropy-hpcp
-        prereq scipy-hpcp
-        prereq matplotlib-hpcp
-        prereq ipython-hpcp
-        prereq yaml-hpcp
-        prereq fitsio-hpcp
-        prereq requests-hpcp
+        prereq desi-conda
     }}
 }}
 


### PR DESCRIPTION
This pull request is mainly just to show how easy it is to switch to the conda stacks on edison, cori, and datatran.  I cannot actually log in to scigate at the moment, so I simply assumed that scigate was close enough to datatran that we could re-use the software stack there.  Certainly it will be no worse than the out of date hpcports on scigate!  @weaverba137, any feedback appreciated.
