### PR TITLE
Post-restructure modules

### DIFF
--- a/etc/desimodules.module
+++ b/etc/desimodules.module
@@ -97,13 +97,12 @@ prereq desitree
 module load specter/0.7.0
 module load desimodel/0.7.0
 module load specex/v0.4.3
-module load desitarget/0.13.0
+module load desitarget/0.14.0
 module load specsim/v0.9
-module load desispec/0.15.1
-module load desisim/0.19.0
+module load desispec/0.15.2
+module load desisim/0.20.0
 module load fiberassign/0.5.0
-module load desisurvey/0.8.1
+module load desisurvey/0.8.2
 module load surveysim/0.7.0
 
 module load redrock/0.4.1
-# module load redmonster/v1.2.0

--- a/etc/desimodules.module
+++ b/etc/desimodules.module
@@ -88,7 +88,7 @@ if {{ [info exists env(NERSC_HOST)] }} {{
 #
 # DESI-specific modules
 #
-module load desiutil/1.9.5
+module load desiutil/1.9.6
 prereq desiutil
 
 module load desitree/0.3.0


### PR DESCRIPTION
In preparation for desimodules/17.7, we are updating the tags of other DESI products: desiutil, desitarget, desispec, desisim, etc.  Merge once all the new tags actually exist and are included.