### PR TITLE
Add release 18.3

### DIFF
--- a/18.3
+++ b/18.3
@@ -89,7 +89,7 @@ module load desitree/0.3.0
 prereq desitree
 
 module load specter/0.8.3
-module load desimodel/0.9.2
+module load desimodel/0.9.3
 module load specex/0.6.0
 module load desitarget/0.20.0
 module load specsim/v0.11

--- a/18.3
+++ b/18.3
@@ -98,6 +98,6 @@ module load desisim/0.27.0
 module load fiberassign/0.8.0
 module load desisurvey/0.10.1
 module load surveysim/0.9.0
-module load redrock/0.10.0
+module load redrock/0.10.1
 module load redrock-templates/0.5
 module load simqso/1.2.2

--- a/18.3
+++ b/18.3
@@ -20,7 +20,7 @@ proc ModulesHelp { } {
 # change it.
 #
 set product desimodules
-set version test-release
+set version 18.3
 conflict $product
 set desiconda_version 20180130-1.2.4-spec
 #

--- a/18.3
+++ b/18.3
@@ -82,22 +82,22 @@ if { [info exists env(NERSC_HOST)] } {
 #
 # DESI-specific modules
 #
-module load desiutil/1.9.9
+module load desiutil/1.9.10
 prereq desiutil
 
 module load desitree/0.3.0
 prereq desitree
 
-module load specter/0.8.3
-module load desimodel/0.9.3
-module load specex/0.6.0
-module load desitarget/0.20.0
+module load specter/0.8.4
+module load desimodel/0.9.4
+module load specex/0.6.1
+module load desitarget/0.20.1
 module load specsim/v0.11
-module load desispec/0.19.0
-module load desisim/0.26.0
-module load fiberassign/0.7.1
+module load desispec/0.20.0
+module load desisim/0.27.0
+module load fiberassign/0.8.0
 module load desisurvey/0.10.1
 module load surveysim/0.9.0
-module load redrock/0.9.0
+module load redrock/0.10.0
 module load redrock-templates/0.5
 module load simqso/1.2.2

--- a/desi_environment.csh
+++ b/desi_environment.csh
@@ -3,18 +3,33 @@
 # It currently only supports NERSC hosts.
 #
 if ( `basename ${SHELL}` == "csh" || `basename ${SHELL}` == "tcsh" ) then
+    if ( $# > 0 ) then
+        set release = "/$1"
+    else
+        set release = ''
+    endif
+    switch ( ${release} )
+        case "/17.*":
+        case '/18.1':
+            set startup = /global/common/${NERSC_HOST}/contrib/desi/desiconda/startup/modulefiles
+            if ( "${NERSC_HOST}" == "datatran" ) then
+                set startup = /global/project/projectdirs/desi/software/${NERSC_HOST}/desiconda/startup/modulefiles
+            endif
+            breaksw
+        default:
+            set startup = /global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
+            breaksw
+    endsw
     if ( "${NERSC_HOST}" == "edison" || \
          "${NERSC_HOST}" == "cori" || \
          "${NERSC_HOST}" == "datatran" ) then
-        module use /global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
+        module use ${startup}
+        module load desimodules${release}
     else
         echo "DESI+Anaconda environment is not supported on ${NERSC_HOST}!"
     endif
-    if ( $# > 0 ) then
-        module load desimodules/$1
-    else
-        module load desimodules
-    endif
+    unset startup
+    unset release
 else
     echo "You are not sourcing the correct file for your shell!"
 endif

--- a/desi_environment.csh
+++ b/desi_environment.csh
@@ -4,32 +4,32 @@
 #
 if ( `basename ${SHELL}` == "csh" || `basename ${SHELL}` == "tcsh" ) then
     if ( $# > 0 ) then
-        set release = "/$1"
+        set _desi_release = "/$1"
     else
-        set release = ''
+        set _desi_release = ''
     endif
-    switch ( ${release} )
+    switch ( ${_desi_release} )
         case "/17.*":
         case '/18.1':
-            set startup = /global/common/${NERSC_HOST}/contrib/desi/desiconda/startup/modulefiles
+            set _desi_startup = /global/common/${NERSC_HOST}/contrib/desi/desiconda/startup/modulefiles
             if ( "${NERSC_HOST}" == "datatran" ) then
-                set startup = /global/project/projectdirs/desi/software/${NERSC_HOST}/desiconda/startup/modulefiles
+                set _desi_startup = /global/project/projectdirs/desi/software/${NERSC_HOST}/desiconda/startup/modulefiles
             endif
             breaksw
         default:
-            set startup = /global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
+            set _desi_startup = /global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
             breaksw
     endsw
     if ( "${NERSC_HOST}" == "edison" || \
          "${NERSC_HOST}" == "cori" || \
          "${NERSC_HOST}" == "datatran" ) then
-        module use ${startup}
-        module load desimodules${release}
+        module use ${_desi_startup}
+        module load desimodules${_desi_release}
     else
         echo "DESI+Anaconda environment is not supported on ${NERSC_HOST}!"
     endif
-    unset startup
-    unset release
+    unset _desi_startup
+    unset _desi_release
 else
     echo "You are not sourcing the correct file for your shell!"
 endif

--- a/desi_environment.sh
+++ b/desi_environment.sh
@@ -3,18 +3,32 @@
 # It currently only supports NERSC hosts.
 #
 if [[ $(basename ${SHELL}) == "bash" || $(basename ${SHELL}) == "sh" ]]; then
+    if [[ $# > 0 ]]; then
+        release="/$1"
+    else
+        release=''
+    fi
+    case ${release} in
+        /17.* | /18.1)
+            startup=/global/common/${NERSC_HOST}/contrib/desi/desiconda/startup/modulefiles
+            if [[ "${NERSC_HOST}" == "datatran" ]]; then
+                startup=/global/project/projectdirs/desi/software/${NERSC_HOST}/desiconda/startup/modulefiles
+            fi
+            ;;
+        *)
+            startup=/global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
+            ;;
+    esac
     if [[ "${NERSC_HOST}" == "edison" || \
           "${NERSC_HOST}" == "cori" || \
           "${NERSC_HOST}" == "datatran" ]]; then
-        module use /global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
+        module use ${startup}
+        module load desimodules${release}
     else
         echo "DESI+Anaconda environment is not supported on ${NERSC_HOST}!"
     fi
-    if [[ $# > 0 ]]; then
-        module load desimodules/$1
-    else
-        module load desimodules
-    fi
+    unset startup
+    unset release
 else
     echo "You are not sourcing the correct file for your shell!"
 fi

--- a/desi_environment.sh
+++ b/desi_environment.sh
@@ -4,31 +4,31 @@
 #
 if [[ $(basename ${SHELL}) == "bash" || $(basename ${SHELL}) == "sh" ]]; then
     if [[ $# > 0 ]]; then
-        release="/$1"
+        _desi_release="/$1"
     else
-        release=''
+        _desi_release=''
     fi
-    case ${release} in
+    case ${_desi_release} in
         /17.* | /18.1)
-            startup=/global/common/${NERSC_HOST}/contrib/desi/desiconda/startup/modulefiles
+            _desi_startup=/global/common/${NERSC_HOST}/contrib/desi/desiconda/startup/modulefiles
             if [[ "${NERSC_HOST}" == "datatran" ]]; then
-                startup=/global/project/projectdirs/desi/software/${NERSC_HOST}/desiconda/startup/modulefiles
+                _desi_startup=/global/project/projectdirs/desi/software/${NERSC_HOST}/desiconda/startup/modulefiles
             fi
             ;;
         *)
-            startup=/global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
+            _desi_startup=/global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
             ;;
     esac
     if [[ "${NERSC_HOST}" == "edison" || \
           "${NERSC_HOST}" == "cori" || \
           "${NERSC_HOST}" == "datatran" ]]; then
-        module use ${startup}
-        module load desimodules${release}
+        module use ${_desi_startup}
+        module load desimodules${_desi_release}
     else
         echo "DESI+Anaconda environment is not supported on ${NERSC_HOST}!"
     fi
-    unset startup
-    unset release
+    unset _desi_startup
+    unset _desi_release
 else
     echo "You are not sourcing the correct file for your shell!"
 fi

--- a/master
+++ b/master
@@ -92,14 +92,14 @@ prereq desitree
 module load specter/master
 module load desimodel/master
 # specex: stable, slow to compile, not updated daily, so use a tag.
-module load specex/0.5.0
+module load specex/0.6.0
 module load desitarget/master
 module load specsim/master
 module load desispec/master
-module load simqso/master
 module load desisim/master
 module load fiberassign/master
 module load desisurvey/master
 module load surveysim/master
 module load redrock/master
 module load redrock-templates/master
+module load simqso/master

--- a/test-release
+++ b/test-release
@@ -98,6 +98,6 @@ module load desisim/0.27.0
 module load fiberassign/0.8.0
 module load desisurvey/0.10.1
 module load surveysim/0.9.0
-module load redrock/0.10.0
+module load redrock/0.10.1
 module load redrock-templates/0.5
 module load simqso/1.2.2

--- a/test-release
+++ b/test-release
@@ -82,22 +82,22 @@ if { [info exists env(NERSC_HOST)] } {
 #
 # DESI-specific modules
 #
-module load desiutil/1.9.9
+module load desiutil/1.9.10
 prereq desiutil
 
 module load desitree/0.3.0
 prereq desitree
 
-module load specter/0.8.3
-module load desimodel/0.9.2
-module load specex/0.6.0
-module load desitarget/0.20.0
+module load specter/0.8.4
+module load desimodel/0.9.4
+module load specex/0.6.1
+module load desitarget/0.20.1
 module load specsim/v0.11
-module load desispec/0.19.0
-module load desisim/0.26.0
-module load fiberassign/0.7.1
+module load desispec/0.20.0
+module load desisim/0.27.0
+module load fiberassign/0.8.0
 module load desisurvey/0.10.1
 module load surveysim/0.9.0
-module load redrock/0.9.0
+module load redrock/0.10.0
 module load redrock-templates/0.5
 module load simqso/1.2.2


### PR DESCRIPTION
This PR adds 18.3 and updates `desi_environment.c?sh` to support both `/global/common/${NERSC_HOST}` and `/global/common/software`.

Do not merge yet!  The actual tags in test-release and 18.3 still need to be updated.