### PR TITLE
Add module for data transfer

### DIFF
--- a/datatran
+++ b/datatran
@@ -22,7 +22,7 @@ proc ModulesHelp { } {
 set product desimodules
 set version master
 conflict $product
-set desiconda_version 20190804-1.3.0-spec
+set desiconda_version 20180102-1.2.2
 #
 # The line below is another part of the Modules help system.  You can
 # modify the part in quotes if you really need to, but most products should
@@ -84,25 +84,25 @@ if { [info exists env(NERSC_HOST)] } {
 #
 # DESI-specific modules
 #
-module load desiutil/master
+module load desiutil/2.0.1
 prereq desiutil
 
 module load desitree/0.4.0
 prereq desitree
 
 # Master versions of most modules:
-module load specter/master
-module load desimodel/master
+# module load specter/master
+# module load desimodel/master
 # specex: stable, slow to compile, not updated daily, so use a tag.
-module load specex/0.6.4
-module load desitarget/master
-module load specsim/master
-module load desispec/master
-module load desisim/master
-module load fiberassign/master
-module load desisurvey/master
-module load surveysim/master
-module load redrock/master
-module load redrock-templates/master
-module load simqso/master
-module load dust/v0_1
+# module load specex/0.6.4
+# module load desitarget/master
+# module load specsim/master
+# module load desispec/master
+# module load desisim/master
+# module load fiberassign/master
+# module load desisurvey/master
+# module load surveysim/master
+# module load redrock/master
+# module load redrock-templates/master
+# module load simqso/master
+# module load dust/v0_1

--- a/master
+++ b/master
@@ -22,7 +22,11 @@ proc ModulesHelp { } {
 set product desimodules
 set version master
 conflict $product
-set desiconda_version 20190804-1.3.0-spec
+if { $env(NERSC_HOST) == "datatran" } {
+    set desiconda_version 20180102-1.2.2
+} else {
+    set desiconda_version 20190804-1.3.0-spec
+}
 #
 # The line below is another part of the Modules help system.  You can
 # modify the part in quotes if you really need to, but most products should


### PR DESCRIPTION
This PR adds a module specifically for the `datatran` hosts, so that a checkout of desimodules will work for both cori and datatran.

While I was working on this, I noticed:

1. The desimodules checkout on cori has a `master` module file that differs from the repository and is not checked in.
2. The desiconda version on datatran is approaching 2 years old.  Is there anything we can do about that?