### PR TITLE
Update to CFS

### DIFF
--- a/19.10
+++ b/19.10
@@ -87,7 +87,7 @@ if { [info exists env(NERSC_HOST)] } {
 module load desiutil/2.0.1
 prereq desiutil
 
-module load desitree/0.4.0
+module load desitree/0.5.0
 prereq desitree
 
 module load specter/0.9.1

--- a/19.12
+++ b/19.12
@@ -66,7 +66,7 @@ if { [info exists env(NERSC_HOST)] } {
 module load desiutil/2.0.1
 prereq desiutil
 
-module load desitree/0.4.0
+module load desitree/0.5.0
 prereq desitree
 
 module load specter/0.9.1

--- a/19.9
+++ b/19.9
@@ -87,7 +87,7 @@ if { [info exists env(NERSC_HOST)] } {
 module load desiutil/2.0.1
 prereq desiutil
 
-module load desitree/0.4.0
+module load desitree/0.5.0
 prereq desitree
 
 module load specter/0.9.1

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ useful for setting up these meta-modules:
     script is meant to be *sourced* inside an existing shell, not executed.
     For example::
 
-        source /global/project/projectdirs/desi/software/desi_environment.sh 19.12
+        source /global/common/software/desi/desi_environment.sh 19.12
 
 ``activate_desi_jupyter.sh``
     Used to set up the DESI environment within Jupyter notebooks.  This

--- a/activate_desi_jupyter.csh
+++ b/activate_desi_jupyter.csh
@@ -9,7 +9,7 @@
 # {
 # "language": "python",
 # "argv": [
-#   "/project/projectdirs/desi/software/activate_desi_jupyter.csh",
+#   "/global/common/software/desi/activate_desi_jupyter.csh",
 #   "17.6",
 #   "{connection_file}"
 #   ],
@@ -19,5 +19,5 @@
 set version = $1
 set connection_file = $2
 
-source /project/projectdirs/desi/software/desi_environment.csh $version
-exec python -m ipykernel -f $connection_file
+source /global/common/software/desi/desi_environment.csh ${version}
+exec python -m ipykernel -f ${connection_file}

--- a/activate_desi_jupyter.sh
+++ b/activate_desi_jupyter.sh
@@ -9,7 +9,7 @@
 # {
 # "language": "python",
 # "argv": [
-#   "/project/projectdirs/desi/software/activate_desi_jupyter.sh",
+#   "/global/common/software/desi/activate_desi_jupyter.sh",
 #   "17.6",
 #   "{connection_file}"
 #   ],
@@ -19,5 +19,5 @@
 version=$1
 connection_file=$2
 
-source /project/projectdirs/desi/software/desi_environment.sh $version
-exec python -m ipykernel -f $connection_file
+source /global/common/software/desi/desi_environment.sh ${version}
+exec python -m ipykernel -f ${connection_file}

--- a/datatran
+++ b/datatran
@@ -84,7 +84,7 @@ if { [info exists env(NERSC_HOST)] } {
 #
 # DESI-specific modules
 #
-module load desiutil/2.0.1
+module load desiutil/2.0.2
 prereq desiutil
 
 module load desitree/0.5.0

--- a/datatran
+++ b/datatran
@@ -87,7 +87,7 @@ if { [info exists env(NERSC_HOST)] } {
 module load desiutil/2.0.1
 prereq desiutil
 
-module load desitree/0.4.0
+module load desitree/0.5.0
 prereq desitree
 
 # Master versions of most modules:

--- a/install_jupyter_kernel.sh
+++ b/install_jupyter_kernel.sh
@@ -73,7 +73,7 @@ cat > ${kernelDir}/kernel.json <<EndOfKernel
 {
  "language": "python",
  "argv": [
-  "/project/projectdirs/desi/software/activate_desi_jupyter.${suffix}",
+  "/global/common/software/desi/activate_desi_jupyter.${suffix}",
   "${release}",
   "{connection_file}"
  ],

--- a/master
+++ b/master
@@ -66,7 +66,7 @@ if { [info exists env(NERSC_HOST)] } {
 module load desiutil/master
 prereq desiutil
 
-module load desitree/0.4.0
+module load desitree/0.5.0
 prereq desitree
 
 # Master versions of most modules:

--- a/test-release
+++ b/test-release
@@ -63,7 +63,7 @@ if { [info exists env(NERSC_HOST)] } {
 #
 # DESI-specific modules
 #
-module load desiutil/2.0.1
+module load desiutil/2.0.2
 prereq desiutil
 
 module load desitree/0.5.0

--- a/test-release
+++ b/test-release
@@ -66,7 +66,7 @@ if { [info exists env(NERSC_HOST)] } {
 module load desiutil/2.0.1
 prereq desiutil
 
-module load desitree/0.4.0
+module load desitree/0.5.0
 prereq desitree
 
 module load specter/0.9.1


### PR DESCRIPTION
This PR updates paths to point to CFS where needed and remove any references to /global/project/projectdirs.

Question: should 19.12 (and any earlier releases) also be updated to use the latest version of desitree?