### PR TITLE
Set DESI_ROOT in desi_environment

### DIFF
--- a/datatran
+++ b/datatran
@@ -90,4 +90,8 @@ prereq desitree
 # module load speclite/0.13
 # module load QuasarNP/0.1.2
 
+setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.2.7
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
+
+# may solve some OpenMP instabilities at NERSC
+# setenv KMP_INIT_AT_FORK FALSE

--- a/datatran
+++ b/datatran
@@ -95,3 +95,4 @@ setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
 
 # may solve some OpenMP instabilities at NERSC
 # setenv KMP_INIT_AT_FORK FALSE
+setenv OMP_NUM_THREADS 1

--- a/desi_environment.csh
+++ b/desi_environment.csh
@@ -20,7 +20,16 @@ if ( `basename ${SHELL}` == "csh" || `basename ${SHELL}` == "tcsh" ) then
             set _desi_startup = /global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
             breaksw
     endsw
-    if ( "${NERSC_HOST}" == "edison" || \
+    if ( ${?DESI_ROOT} ) then
+        # Do nothing, successfully.
+        :
+    else if ( ${?NERSC_HOST} ) then
+        setenv DESI_ROOT /global/cfs/cdirs/desi
+    else
+        echo "Could not determine a valid value of DESI_ROOT!"
+        exit
+    endif
+    if ( "${NERSC_HOST}" == "perlmutter" || \
          "${NERSC_HOST}" == "cori" || \
          "${NERSC_HOST}" == "datatran" ) then
         module use ${_desi_startup}

--- a/desi_environment.sh
+++ b/desi_environment.sh
@@ -19,7 +19,16 @@ if [[ $(basename ${SHELL}) == "bash" || $(basename ${SHELL}) == "sh" ]]; then
             _desi_startup=/global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
             ;;
     esac
-    if [[ "${NERSC_HOST}" == "edison" || \
+    if [[ -n "${DESI_ROOT}" ]]; then
+        # Do nothing, successfully.
+        :
+    elif [[ -n "${NERSC_HOST}" ]]; then
+        export DESI_ROOT=/global/cfs/cdirs/desi
+    else
+        echo "Could not determine a valid value of DESI_ROOT!"
+        return
+    fi
+    if [[ "${NERSC_HOST}" == "perlmutter" || \
           "${NERSC_HOST}" == "cori" || \
           "${NERSC_HOST}" == "datatran" ]]; then
         module use ${_desi_startup}

--- a/main
+++ b/main
@@ -90,4 +90,8 @@ module load dust/v0_1
 module load speclite/0.13
 module load QuasarNP/0.1.2
 
+setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.2.7
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
+
+# may solve some OpenMP instabilities at NERSC
+setenv KMP_INIT_AT_FORK FALSE


### PR DESCRIPTION
This PR prepares for Lmod on Perlmutter by moving the definition of `DESI_ROOT` into the `desi_environment.(sh|csh)` scripts.  In addition "edison" is replaced with "permutter" and some environment variables are added to the `main` module for compatibility with `21.7e`.