### PR TITLE
Fix perlmutter environment variables; remove support for older versions; catch missing modules on perlmutter

### DIFF
--- a/activate_desi_jupyter.csh
+++ b/activate_desi_jupyter.csh
@@ -16,8 +16,12 @@
 # "display_name": "DESI 17.6"
 # }
 
+set _a = `alias module`
+if ( "${_a}" == "" ) source /usr/share/lmod/lmod/init/tcsh
+unset _a
+
 set version = $1
 set connection_file = $2
 
 source /global/common/software/desi/desi_environment.csh ${version}
-exec python -m ipykernel -f ${connection_file}
+exec python -m ipykernel_launcher -f ${connection_file}

--- a/activate_desi_jupyter.sh
+++ b/activate_desi_jupyter.sh
@@ -16,8 +16,12 @@
 # "display_name": "DESI 17.6"
 # }
 
+_i=bash
+[[ $(basename ${SHELL}) == "zsh" ]] && _i=zsh
+[[ $(declare -F module) ]] || source /usr/share/lmod/lmod/init/${_i}
+
 version=$1
 connection_file=$2
 
 source /global/common/software/desi/desi_environment.sh ${version}
-exec python -m ipykernel -f ${connection_file}
+exec python -m ipykernel_launcher -f ${connection_file}

--- a/desi_environment.csh
+++ b/desi_environment.csh
@@ -8,18 +8,7 @@ if ( `basename ${SHELL}` == "csh" || `basename ${SHELL}` == "tcsh" ) then
     else
         set _desi_release = ''
     endif
-    switch ( ${_desi_release} )
-        case "/17.*":
-        case '/18.1':
-            set _desi_startup = /global/common/${NERSC_HOST}/contrib/desi/desiconda/startup/modulefiles
-            if ( "${NERSC_HOST}" == "datatran" ) then
-                set _desi_startup = /global/project/projectdirs/desi/software/${NERSC_HOST}/desiconda/startup/modulefiles
-            endif
-            breaksw
-        default:
-            set _desi_startup = /global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
-            breaksw
-    endsw
+    set _desi_startup = /global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
     if ( ${?DESI_ROOT} ) then
         # Do nothing, successfully.
         :

--- a/desi_environment.sh
+++ b/desi_environment.sh
@@ -8,17 +8,7 @@ if [[ $(basename ${SHELL}) == "bash" || $(basename ${SHELL}) == "sh" || $(basena
     else
         _desi_release=''
     fi
-    case ${_desi_release} in
-        /17.* | /18.1)
-            _desi_startup=/global/common/${NERSC_HOST}/contrib/desi/desiconda/startup/modulefiles
-            if [[ "${NERSC_HOST}" == "datatran" ]]; then
-                _desi_startup=/global/project/projectdirs/desi/software/${NERSC_HOST}/desiconda/startup/modulefiles
-            fi
-            ;;
-        *)
-            _desi_startup=/global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
-            ;;
-    esac
+    _desi_startup=/global/common/software/desi/${NERSC_HOST}/desiconda/startup/modulefiles
     if [[ -n "${DESI_ROOT}" ]]; then
         # Do nothing, successfully.
         :

--- a/main
+++ b/main
@@ -24,14 +24,14 @@ set version main
 conflict $product
 set desiconda_version 20211217-2.0.0
 if {[info exists env(NERSC_HOST)]} {
-   if { $env(NERSC_HOST) == "perlmutter" } {
-      set desiconda_version 20220119-2.0.1
-      # https://docs.nersc.gov/current/#ongoing-issues
-      set MPI4PY_RC_RECV_MPROBE 'False'
-      # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
-      set IBV_FORK_SAFE 1
-      set RDMAV_HUGEPAGES_SAFE 1
-   }
+    if { $env(NERSC_HOST) == "perlmutter" } {
+        set desiconda_version 20220119-2.0.1
+        # https://docs.nersc.gov/current/#ongoing-issues
+        setenv MPI4PY_RC_RECV_MPROBE "False"
+        # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
+        setenv IBV_FORK_SAFE 1
+        setenv RDMAV_HUGEPAGES_SAFE 1
+    }
 }
 #
 # The line below is another part of the Modules help system.  You can
@@ -105,4 +105,3 @@ setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
 
 # may solve some OpenMP instabilities at NERSC
 setenv KMP_INIT_AT_FORK FALSE
-


### PR DESCRIPTION
This PR

* Closes #37.
* Closes #39.
* Fixes a bug where `set` instead of `setenv` was used for certain environment variables were meant to be set for perlmutter. I verified that NERSC's documentation says that these should be real environment variables.

Further discussion of #39: While investigating NERSC ticket INC0188543, we discovered that the `module` command is unavailable in tcsh *subshells*.  This is due to vendor-supplied configuration on perlmutter. While bash appears unaffected, that is again due to vendor-supplied configuration rather than any inherent properties of bash, so `activate_desi_jupyter.(sh|csh)` is updated to work around missing `module` in both cases.  If `module` is already present, the check does nothing.

Side note: the vendor-supplied configuration is even worse for zsh, apparently.  We may want to re-think supporting that shell.

@sbailey: At this point the module files for 17.x and 18.x are still in place, but would be inaccessible via `desi_environment.(sh|csh)`. We can remove those as part of this PR, or leave them in place.  Given changes to environment, compilers, etc. over the years it seems unlikely that anyone would want to use these old versions, but we can discuss.  I vote for removing them because they would still be visible in `module avail desimodules` if we don't and that could cause confusion.