### PR TITLE
master renamed to main

### DIFF
--- a/main
+++ b/main
@@ -73,31 +73,31 @@ if { [info exists env(NERSC_HOST)] } {
 #
 # DESI-specific modules
 #
-module load desiutil/master
+module load desiutil/main
 prereq desiutil
 
 module load desitree/0.5.0
 prereq desitree
 
 # Master versions of most modules:
-module load specter/master
-module load gpu_specter/master
-module load desimodel/master
-module load specex/master
-module load desitarget/master
-module load specsim/master
-module load desispec/master
-module load desisim/master
-module load fiberassign/master
-module load desisurvey/master
-module load surveysim/master
-module load redrock/master
-module load redrock-templates/master
-module load prospect/master
-module load desimeter/master
-module load simqso/master
+module load specter/main
+module load gpu_specter/main
+module load desimodel/main
+module load specex/main
+module load desitarget/main
+module load specsim/main
+module load desispec/main
+module load desisim/main
+module load fiberassign/main
+module load desisurvey/main
+module load surveysim/main
+module load redrock/main
+module load redrock-templates/main
+module load prospect/main
+module load desimeter/main
+module load simqso/main
 module load dust/v0_1
-module load speclite/master
+module load speclite/main
 module load QuasarNP/0.1.3
 
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk


### PR DESCRIPTION
This PR switches all of the modules loaded to use "main" instead of "master".  The "main" branch of all of these have been installed on both cori and perlmutter, and this desimodules/main has been tested for loading them.  I wouldn't be surprised if there are still some hiccups, but those are most likely in the individual packages not in this desimodules/main package.  I plan to self merge so that we can update both cori and perlmutter to keep in sync.