### PR TITLE
Update environment variables on Perlmutter

### DIFF
--- a/main
+++ b/main
@@ -29,8 +29,8 @@ if {[info exists env(NERSC_HOST)]} {
         # https://docs.nersc.gov/current/#ongoing-issues
         setenv MPI4PY_RC_RECV_MPROBE "False"
         # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
-        setenv IBV_FORK_SAFE 1
-        setenv RDMAV_HUGEPAGES_SAFE 1
+        setenv CXI_FORK_SAFE 1
+        setenv CXI_FORK_SAFE_HP 1
     }
 }
 #


### PR DESCRIPTION
Update the environment variables to mitigate MPI gather errors on Perlmutter that may be caused by undefined behavior when forking in MPI processes. 

On Perlmutter nodes with Slingshot 10 with Mellanox/InfiniBand, i.e.
```
IBV_FORK_SAFE=1
RDMAV_HUGEPAGES_SAFE=1
```
Now that all Perlmutter nodes use Slingshot 11 with Cassini, the appropriate environment variables are instead
```
CXI_FORK_SAFE=1
CXI_FORK_SAFE_HP=1
```
See [here](https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#issues-with-fork-in-mpi-processes ) for more details. 

Thanks @dmargala for the heads up and diagnosis before and after the pipeline began failing on Perlmutter, respectively. 