### PR TITLE
desi environment patches for perlmutter

### DIFF
--- a/22.2
+++ b/22.2
@@ -26,6 +26,12 @@ set desiconda_version 20211217-2.0.0
 if {[info exists env(NERSC_HOST)]} {
    if { $env(NERSC_HOST) == "perlmutter" } {
       set desiconda_version 20220119-2.0.1
+      # https://docs.nersc.gov/current/#ongoing-issues
+      setenv MPI4PY_RC_RECV_MPROBE "False"
+      # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
+      setenv CXI_FORK_SAFE 1
+      setenv CXI_FORK_SAFE_HP 1
+      module unload cudatoolkit
    }
 }
 #
@@ -101,4 +107,11 @@ setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.3.1
 # may solve some OpenMP instabilities at NERSC
 setenv KMP_INIT_AT_FORK FALSE
 
+# work around
+# https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
+if { [info exists env(NERSC_HOST)] } {
+    if { $env(NERSC_HOST) == "perlmutter" } {
+        module load evp-patch
+    }
+}
 

--- a/22.5
+++ b/22.5
@@ -22,10 +22,17 @@ proc ModulesHelp { } {
 set product desimodules
 set version 22.5
 conflict $product
-if { $env(NERSC_HOST) == "perlmutter" } {
-  set desiconda_version 20220119-2.0.1
-} else {
-  set desiconda_version 20211217-2.0.0
+set desiconda_version 20211217-2.0.0
+if {[info exists env(NERSC_HOST)]} {
+    if { $env(NERSC_HOST) == "perlmutter" } {
+        set desiconda_version 20220119-2.0.1
+        # https://docs.nersc.gov/current/#ongoing-issues
+        setenv MPI4PY_RC_RECV_MPROBE "False"
+        # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
+        setenv CXI_FORK_SAFE 1
+        setenv CXI_FORK_SAFE_HP 1
+        module unload cudatoolkit
+    }
 }
 #
 # The line below is another part of the Modules help system.  You can
@@ -101,4 +108,11 @@ setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
 # may solve some OpenMP instabilities at NERSC
 setenv KMP_INIT_AT_FORK FALSE
 
+# work around
+# https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
+if { [info exists env(NERSC_HOST)] } {
+    if { $env(NERSC_HOST) == "perlmutter" } {
+        module load evp-patch
+    }
+}
 

--- a/main
+++ b/main
@@ -31,6 +31,7 @@ if {[info exists env(NERSC_HOST)]} {
         # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
         setenv CXI_FORK_SAFE 1
         setenv CXI_FORK_SAFE_HP 1
+        module unload cudatoolkit
     }
 }
 #
@@ -79,7 +80,7 @@ prereq desiutil
 module load desitree/0.6.0
 prereq desitree
 
-# Master versions of most modules:
+# main versions of most modules:
 module load specter/main
 module load gpu_specter/main
 module load desimodel/main
@@ -105,3 +106,12 @@ setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
 
 # may solve some OpenMP instabilities at NERSC
 setenv KMP_INIT_AT_FORK FALSE
+
+# work around
+# https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
+if { [info exists env(NERSC_HOST)] } {
+    if { $env(NERSC_HOST) == "perlmutter" } {
+        module load evp-patch
+    }
+}
+


### PR DESCRIPTION
This PR provides some patches to the DESI environment on perlmutter.

Changes we've been running with for awhile on main, but hadn't committed:
* MPI4PY_RC_RECV_MPROBE="False"
* CXI_FORK_SAFE=1
* CXI_FORK_SAFE_HP=1
* "module unload cudatoolkit" retroactively added to 22.2 and 22.5 to avoid conflict between NERSC/HPE-provided cudatoolkit and the version in our conda environment (we've been doing this on main, but not the older environments)

New here:
* Added "module load evp-patch" to work around a library symbol issue introduced in the Dec 2022 maintenance, described at https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
  * Note: the issue was caused by the libraries provided by HPE/Cray; thanks to NERSC for proactively catching this and providing the evp-patch module as a simple workaround so that we don't have to rebuild our environments.

Without "module load evp-patch":
```
<perlmutter ~> srun -n 2 python -m mpi4py.bench helloworld
Traceback (most recent call last):
  File "/global/common/software/desi/perlmutter/desiconda/20220119-2.0.1/conda/lib/python3.9/runpy.py", line 197, in _run_module_as_main
Traceback (most recent call last):
  File "/global/common/software/desi/perlmutter/desiconda/20220119-2.0.1/conda/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/global/common/software/desi/perlmutter/desiconda/20220119-2.0.1/conda/lib/python3.9/runpy.py", line 87, in _run_code
    return _run_code(code, main_globals, None,
  File "/global/common/software/desi/perlmutter/desiconda/20220119-2.0.1/conda/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/global/common/software/desi/perlmutter/desiconda/20220119-2.0.1/conda/lib/python3.9/site-packages/mpi4py/bench.py", line 169, in <module>
    exec(code, run_globals)
  File "/global/common/software/desi/perlmutter/desiconda/20220119-2.0.1/conda/lib/python3.9/site-packages/mpi4py/bench.py", line 169, in <module>
    main()
  File "/global/common/software/desi/perlmutter/desiconda/20220119-2.0.1/conda/lib/python3.9/site-packages/mpi4py/bench.py", line 152, in main
    main()
  File "/global/common/software/desi/perlmutter/desiconda/20220119-2.0.1/conda/lib/python3.9/site-packages/mpi4py/bench.py", line 152, in main
    from . import MPI
    from . import MPI
ImportError: /usr/lib64/libssh.so.4: undefined symbol: EVP_KDF_CTX_new_id, version OPENSSL_1_1_1d
ImportError: /usr/lib64/libssh.so.4: undefined symbol: EVP_KDF_CTX_new_id, version OPENSSL_1_1_1d
srun: error: nid004569: tasks 0-1: Exited with exit code 1
srun: launch/slurm: _step_signal: Terminating StepId=4006887.0
```

With "module load evp-patch" included in the environment:
```
<perlmutter ~> srun -n 2 python -m mpi4py.bench helloworld
Hello, World! I am process 0 of 2 on nid004561.
Hello, World! I am process 1 of 2 on nid004561.
```
Thanks to @lastephey for showing me that handy mpi4py test, and to her and @dmargala and others at NERSC for catching the problem and working with HPE/Cray to develop the workaround.

Note: github is saying this can't be automatically merged, which might indicate that our perlmutter main environment wasn't updated at NERSC before I branched, so I may have some merge conflicts to resolve.