### PR TITLE
update desiconda on perlmutter

### DIFF
--- a/main
+++ b/main
@@ -25,7 +25,7 @@ conflict $product
 set desiconda_version 20211217-2.0.0
 if {[info exists env(NERSC_HOST)]} {
     if { $env(NERSC_HOST) == "perlmutter" } {
-        set desiconda_version 20220119-2.0.1
+        set desiconda_version 20230111-2.1.0
         # https://docs.nersc.gov/current/#ongoing-issues
         setenv MPI4PY_RC_RECV_MPROBE "False"
         # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues


### PR DESCRIPTION
Solves #45 by updating main to load desiconda/20230111-2.1.0 on perlmutter. Daily updates proceed with the same successes and failures (after desiInstalling desisim-testdata and desisurveyops) as with  desiconda/20220119-2.0.1 and no problems are anticipated. 

Merging now.