### PR TITLE
Module switch in kernel activation

### DIFF
--- a/22.5
+++ b/22.5
@@ -100,6 +100,7 @@ module load speclite/v0.15
 module load QuasarNP/0.1.3
 module load desietc/0.1.14
 module load gpu_specter/master
+module load specprod-db/1.1.0
 
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
 

--- a/23.1
+++ b/23.1
@@ -101,7 +101,7 @@ module load simqso/v1.3.0
 module load dust/v0_1
 module load speclite/v0.16
 module load QuasarNP/0.1.3
-module load specprod-db/0.9.0
+module load specprod-db/1.1.0
 
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.4.0
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk

--- a/activate_desi_jupyter.csh
+++ b/activate_desi_jupyter.csh
@@ -20,8 +20,18 @@ set _a = `alias module`
 if ( "${_a}" == "" ) source /usr/share/lmod/lmod/init/tcsh
 unset _a
 
-set version = $1
-set connection_file = $2
+if ( $# == 3 ) then
+    set version = $1
+    set release = $2
+    set connection_file = $3
+else
+    set version = $1
+    set release = ''
+    set connection_file = $2
+endif
 
 source /global/common/software/desi/desi_environment.csh ${version}
+if ( ${%release} != 0 ) then
+    module switch desitree/${release}
+endif
 exec python -m ipykernel_launcher -f ${connection_file}

--- a/activate_desi_jupyter.sh
+++ b/activate_desi_jupyter.sh
@@ -20,8 +20,18 @@ _i=bash
 [[ $(basename ${SHELL}) == "zsh" ]] && _i=zsh
 [[ $(declare -F module) ]] || source /usr/share/lmod/lmod/init/${_i}
 
-version=$1
-connection_file=$2
+if [[ $# == 3 ]]; then
+    version=$1
+    release=$2
+    connection_file=$3
+else
+    version=$1
+    release=''
+    connection_file=$2
+fi
 
 source /global/common/software/desi/desi_environment.sh ${version}
+if [[ -n "${release}" ]]; then
+    module switch desitree/${release}
+fi
 exec python -m ipykernel_launcher -f ${connection_file}


### PR DESCRIPTION
This PR fixes #47.

We are still testing this, but the basic idea starts with the command-line version for a typical non-DESI user:
```
source /global/common/software/desi/desi_environment.sh 23.1
module switch desitree/edr
```

The `desitree/edr` module already exists, although we may still make some changes to it depending on how we want to handle paths that do not and will never point into the EDR tree.

The `activate_desi_jupyter.(csh|sh)` scripts are modified to accept 2 or 3 arguments.  The two-argument version is backward-compatible with any kernel installed by `install_jupyter_kernel.sh`.  The three-argument version is compatible with pre-built kernel files provided in `/global/common/software/desi/kernels`.  See the `README.md` file in that directory for details.

@forero, we hope this will solve the public kernel issue for the tutorials. Everything should already be set up for use on perlmutter. Please test, using the pre-built public kernels mentioned above.