### PR TITLE
QuasarNP back to 0.2.0 for compatibility with desispec main

### DIFF
--- a/main
+++ b/main
@@ -103,7 +103,7 @@ module load desimeter/main
 module load simqso/main
 module load dust/v0_1
 module load speclite/main
-module load QuasarNP/0.1.5
+module load QuasarNP/0.2.0
 module load specprod-db/main
 
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk


### PR DESCRIPTION
This moves QuasarNP back to 0.2.0 for compatibility with `desispec` main changes that don't allow it to use 0.1.5. The `desispec` changes were introduced in [desispec PR 2230](https://github.com/desihub/desispec/pull/2230).