### PR TITLE
Remove multiply-defined environment variables

### DIFF
--- a/main
+++ b/main
@@ -23,15 +23,15 @@ set product desimodules
 set version main
 conflict $product
 set desiconda_version 20211217-2.0.0
-if {[info exists env(NERSC_HOST)]} {
+if { [info exists env(NERSC_HOST)] } {
     if { $env(NERSC_HOST) == "perlmutter" } {
         set desiconda_version 20240425-2.2.0
         # https://docs.nersc.gov/current/#ongoing-issues
-        setenv MPI4PY_RC_RECV_MPROBE "False"
+        # setenv MPI4PY_RC_RECV_MPROBE "False"
         # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
-        setenv CXI_FORK_SAFE 1
-        setenv CXI_FORK_SAFE_HP 1
-        module unload cudatoolkit
+        # setenv CXI_FORK_SAFE 1
+        # setenv CXI_FORK_SAFE_HP 1
+        # module unload cudatoolkit
     }
 }
 #
@@ -70,10 +70,6 @@ if { [info exists env(NERSC_HOST)] } {
     module use $desiconda_modules_root
     module load desiconda/$desiconda_version
     prereq desiconda
-    setenv DESI_ROOT_READONLY /dvs_ro/cfs/cdirs/desi
-
-    # Use NERSC provided cudatoolkit
-    module load cudatoolkit/12.2
 }
 #
 # DESI-specific modules
@@ -101,21 +97,38 @@ module load redrock-templates/main
 module load prospect/main
 module load desimeter/main
 module load simqso/main
-module load dust/v0_1
+# module load dust/v0_1
 module load speclite/main
 module load QuasarNP/0.2.0
 module load specprod-db/main
 
+#
+# Environment variables that point to checkouts of software products, or
+# similar calibration products.
+#
+setenv DESI_ROOT_READONLY /dvs_ro/cfs/cdirs/desi
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
-
-# may solve some OpenMP instabilities at NERSC
-setenv KMP_INIT_AT_FORK FALSE
-
+set dust_version v0_1
+setenv DUST_DIR /global/cfs/cdirs/cosmo/data/dust/$dust_version
+setenv DUST_VERSION $dust_version
+#
+# NERSC performance settings.
+#
 # work around
 # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
 if { [info exists env(NERSC_HOST)] } {
     if { $env(NERSC_HOST) == "perlmutter" } {
+        # may solve some OpenMP instabilities at NERSC
+        setenv KMP_INIT_AT_FORK FALSE
+        # https://docs.nersc.gov/current/#ongoing-issues
+        setenv MPI4PY_RC_RECV_MPROBE "False"
+        # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
+        setenv CXI_FORK_SAFE 1
+        setenv CXI_FORK_SAFE_HP 1
+        module unload cudatoolkit
+        # Use NERSC provided cudatoolkit
+        module load cudatoolkit/12.2
         module load evp-patch
     }
 }

--- a/main
+++ b/main
@@ -22,7 +22,14 @@ proc ModulesHelp { } {
 set product desimodules
 set version main
 conflict $product
-set desiconda_version 20211217-2.0.0
+
+# NOTE: As of 2024-07-19, KPNO sets $DESI_PRODUCT_ROOT and
+# "module load desiconda" before loading desimodules,
+# in which case this desiconda_version isn't used at all.
+# The current structure is a leftover from supporting
+# cori+perlmutter, and it might be useful again in the future,
+# even if the if blocks are overkill right now.
+set desiconda_version 20240425-2.2.0
 if { [info exists env(NERSC_HOST)] } {
     if { $env(NERSC_HOST) == "perlmutter" } {
         set desiconda_version 20240425-2.2.0

--- a/main
+++ b/main
@@ -100,7 +100,9 @@ module load specprod-db/main
 # Environment variables that point to checkouts of software products, or
 # similar calibration products.
 #
-setenv DESI_ROOT_READONLY /dvs_ro/cfs/cdirs/desi
+if { [info exists env(NERSC_HOST) ] } {
+    setenv DESI_ROOT_READONLY /dvs_ro/cfs/cdirs/desi
+}
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
 setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/latest
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
@@ -108,37 +110,41 @@ setenv DESI_TILES $env(DESI_ROOT)/target/fiberassign/tiles/trunk
 setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
 setenv SQ_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/sq_models/BOSS_train_64plates_model.json
 set dust_version v0_1
-setenv DUST_DIR /global/cfs/cdirs/cosmo/data/dust/$dust_version
+setenv DUST_DIR $env(DESI_ROOT)/external/dust/$dust_version
 setenv DUST_VERSION $dust_version
 #
 # NERSC performance settings.
 # See e.g., https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
 #
+# Although these environment variables are somewhat NERSC-specific, they should
+# be harmless if set elsewhere.
+#
+# May solve some OpenMP instabilities at NERSC, however it is no longer known what those actual instabilities were.
+# See discussion in https://github.com/desihub/desimodules/pull/52.
+setenv KMP_INIT_AT_FORK FALSE
+# As of 2024, this is no longer listed as an ongoing issue in https://docs.nersc.gov/current/#ongoing-issues.
+# See discussion in https://github.com/desihub/desimodules/pull/52.
+setenv MPI4PY_RC_RECV_MPROBE "False"
+# https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#issues-with-fork-in-mpi-processes
+setenv CXI_FORK_SAFE 1
+setenv CXI_FORK_SAFE_HP 1
+# Consolidated from desispec, redrock & fastspecfit module files.
+setenv KMP_AFFINITY disabled
+# Consolidated from desispec, redrock & fastspecfit module files.
+setenv MPICH_GNI_FORK_MODE FULLCOPY
+# Consolidated from redrock & fastspecfit module files.
+setenv OMP_NUM_THREADS 1
+# Moved from redrock module file.
+setenv HDF5_USE_FILE_LOCKING FALSE
+# Moved from fastspecfit module file.
+setenv MKL_NUM_THREADS 1
+#
+# Settings that can *only* be set at NERSC.
+#
 if { [info exists env(NERSC_HOST)] } {
     if { $env(NERSC_HOST) == "perlmutter" } {
-        # May solve some OpenMP instabilities at NERSC, however it is no longer known what those actual instabilities were.
-        # See discussion in https://github.com/desihub/desimodules/pull/52.
-        setenv KMP_INIT_AT_FORK FALSE
-        # As of 2024, this is no longer listed as an ongoing issue in https://docs.nersc.gov/current/#ongoing-issues.
-        # See discussion in https://github.com/desihub/desimodules/pull/52.
-        setenv MPI4PY_RC_RECV_MPROBE "False"
-        # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#issues-with-fork-in-mpi-processes
-        setenv CXI_FORK_SAFE 1
-        setenv CXI_FORK_SAFE_HP 1
-        # Consolidated from desispec, redrock & fastspecfit module files.
-        setenv KMP_AFFINITY disabled
-        # Consolidated from desispec, redrock & fastspecfit module files.
-        setenv MPICH_GNI_FORK_MODE FULLCOPY
-        # Consolidated from redrock & fastspecfit module files.
-        setenv OMP_NUM_THREADS 1
-        # Moved from redrock module file.
-        setenv HDF5_USE_FILE_LOCKING FALSE
-        # Moved from fastspecfit module file.
-        setenv MKL_NUM_THREADS 1
-        # Not clear why this is required because cudatoolkit/12.2 is the default anyway.
-        module unload cudatoolkit
-        # Use NERSC provided cudatoolkit
-        module load cudatoolkit/12.2
+        # Use a specific version of cudatoolkit.
+        module swap cudatoolkit/12.2
         # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#conda-cray-mpich-libfabric-dependencies-missing-evp-symbols
         module load evp-patch
     }

--- a/main
+++ b/main
@@ -106,7 +106,7 @@ if { [info exists env(NERSC_HOST) ] } {
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
 setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/latest
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
-setenv DESI_TILES $env(DESI_ROOT)/target/fiberassign/tiles/trunk
+setenv FIBER_ASSIGN_DIR $env(DESI_ROOT)/target/fiberassign/tiles/trunk
 setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
 setenv SQ_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/sq_models/BOSS_train_64plates_model.json
 set dust_version v0_1

--- a/main
+++ b/main
@@ -26,12 +26,6 @@ set desiconda_version 20211217-2.0.0
 if { [info exists env(NERSC_HOST)] } {
     if { $env(NERSC_HOST) == "perlmutter" } {
         set desiconda_version 20240425-2.2.0
-        # https://docs.nersc.gov/current/#ongoing-issues
-        # setenv MPI4PY_RC_RECV_MPROBE "False"
-        # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
-        # setenv CXI_FORK_SAFE 1
-        # setenv CXI_FORK_SAFE_HP 1
-        # module unload cudatoolkit
     }
 }
 #
@@ -108,7 +102,11 @@ module load specprod-db/main
 #
 setenv DESI_ROOT_READONLY /dvs_ro/cfs/cdirs/desi
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
+setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/latest
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
+setenv DESI_TILES $env(DESI_ROOT)/target/fiberassign/tiles/trunk
+setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
+setenv SQ_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/sq_models/BOSS_train_64plates_model.json
 set dust_version v0_1
 setenv DUST_DIR /global/cfs/cdirs/cosmo/data/dust/$dust_version
 setenv DUST_VERSION $dust_version
@@ -118,13 +116,26 @@ setenv DUST_VERSION $dust_version
 #
 if { [info exists env(NERSC_HOST)] } {
     if { $env(NERSC_HOST) == "perlmutter" } {
-        # may solve some OpenMP instabilities at NERSC
+        # May solve some OpenMP instabilities at NERSC, however it is no longer known what those actual instabilities were.
+        # See discussion in https://github.com/desihub/desimodules/pull/52.
         setenv KMP_INIT_AT_FORK FALSE
-        # https://docs.nersc.gov/current/#ongoing-issues
+        # As of 2024, this is no longer listed as an ongoing issue in https://docs.nersc.gov/current/#ongoing-issues.
+        # See discussion in https://github.com/desihub/desimodules/pull/52.
         setenv MPI4PY_RC_RECV_MPROBE "False"
         # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#issues-with-fork-in-mpi-processes
         setenv CXI_FORK_SAFE 1
         setenv CXI_FORK_SAFE_HP 1
+        # Consolidated from desispec, redrock & fastspecfit module files.
+        setenv KMP_AFFINITY disabled
+        # Consolidated from desispec, redrock & fastspecfit module files.
+        setenv MPICH_GNI_FORK_MODE FULLCOPY
+        # Consolidated from redrock & fastspecfit module files.
+        setenv OMP_NUM_THREADS 1
+        # Moved from redrock module file.
+        setenv HDF5_USE_FILE_LOCKING FALSE
+        # Moved from fastspecfit module file.
+        setenv MKL_NUM_THREADS 1
+        # Not clear why this is required because cudatoolkit/12.2 is the default anyway.
         module unload cudatoolkit
         # Use NERSC provided cudatoolkit
         module load cudatoolkit/12.2

--- a/main
+++ b/main
@@ -114,21 +114,21 @@ setenv DUST_DIR /global/cfs/cdirs/cosmo/data/dust/$dust_version
 setenv DUST_VERSION $dust_version
 #
 # NERSC performance settings.
+# See e.g., https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
 #
-# work around
-# https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
 if { [info exists env(NERSC_HOST)] } {
     if { $env(NERSC_HOST) == "perlmutter" } {
         # may solve some OpenMP instabilities at NERSC
         setenv KMP_INIT_AT_FORK FALSE
         # https://docs.nersc.gov/current/#ongoing-issues
         setenv MPI4PY_RC_RECV_MPROBE "False"
-        # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#mpi-issues
+        # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#issues-with-fork-in-mpi-processes
         setenv CXI_FORK_SAFE 1
         setenv CXI_FORK_SAFE_HP 1
         module unload cudatoolkit
         # Use NERSC provided cudatoolkit
         module load cudatoolkit/12.2
+        # https://docs.nersc.gov/development/languages/python/using-python-perlmutter/#conda-cray-mpich-libfabric-dependencies-missing-evp-symbols
         module load evp-patch
     }
 }


### PR DESCRIPTION
This PR closes #49.

Important question for @sbailey, @marcelo-alvarez, @akremin, @tskisner: we've decided to consolidate the definition of various NERSC-performance environment variables, *e.g.* `KMP_INIT_AT_FORK`. Was there a specific reason that the environment variables were defined in several different places in the module file, *i.e.*, the definitions have to be made *before* at least some DESI modules are loaded?