### PR TITLE
switch main to new QuasarNet model file v1.3 used for Kibo

### DIFF
--- a/main
+++ b/main
@@ -117,7 +117,7 @@ setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/trunk
 setenv DESI_SPECTRO_DARK $env(DESI_ROOT)/spectro/desi_spectro_dark/latest
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk
 setenv FIBER_ASSIGN_DIR $env(DESI_ROOT)/target/fiberassign/tiles/trunk
-setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_train_coadd_indtrain_0_0_boss10.h5
+setenv QN_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/qn_models/qn_desi+eboss_4layers_log_grid_v1.3.h5
 setenv SQ_MODEL_FILE $env(DESI_ROOT)/target/catalogs/lya/sq_models/BOSS_train_64plates_model.json
 set dust_version v0_1
 setenv DUST_DIR $env(DESI_ROOT)/external/dust/$dust_version


### PR DESCRIPTION
This PR updates the main config to use the QuasarNet model file `$QN_MODEL_FILE=$DESI_ROOT/target/catalogs/lya/qn_models/qn_desi+eboss_4layers_log_grid_v1.3.h5` the same as Kibo (24.8 software release).

This has been discussed on the surveyops telecons, so I plan to self-merge + deploy.

Note: desihub/desispec#2402 now also records the value of $QN_MODEL_FILE in the qso_qn model file headers.  These will be deployed together starting with the night of 20241105.