### PR TITLE
Update specprod-db versions

### DIFF
--- a/23.10
+++ b/23.10
@@ -101,7 +101,7 @@ module load simqso/v1.3.0
 module load dust/v0_1
 module load speclite/v0.17
 module load QuasarNP/0.1.3
-module load specprod-db/1.1.0
+module load specprod-db/1.2.0
 module load fastspecfit/2.4.2
 
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.5.0

--- a/23.6
+++ b/23.6
@@ -101,7 +101,7 @@ module load simqso/v1.3.0
 module load dust/v0_1
 module load speclite/v0.16
 module load QuasarNP/0.1.3
-module load specprod-db/1.1.0
+module load specprod-db/1.2.0
 
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.5.0
 setenv DESI_SURVEYOPS $env(DESI_ROOT)/survey/ops/surveyops/trunk

--- a/24.11
+++ b/24.11
@@ -102,7 +102,7 @@ module load desimeter/0.7.1
 module load simqso/v1.3.0
 module load speclite/v0.20
 module load QuasarNP/0.2.0
-module load specprod-db/1.1.0
+module load specprod-db/1.3.0
 module load fastspecfit/2.5.2
 
 

--- a/24.4
+++ b/24.4
@@ -103,7 +103,7 @@ module load simqso/v1.3.0
 module load dust/v0_1
 module load speclite/v0.19
 module load QuasarNP/0.2.0
-module load specprod-db/1.1.0
+module load specprod-db/1.3.0
 module load fastspecfit/2.5.2
 
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.6.0

--- a/24.6
+++ b/24.6
@@ -103,7 +103,7 @@ module load simqso/v1.3.0
 module load dust/v0_1
 module load speclite/v0.19
 module load QuasarNP/0.2.0
-module load specprod-db/1.1.0
+module load specprod-db/1.3.0
 module load fastspecfit/2.5.2
 
 setenv DESI_SPECTRO_CALIB $env(DESI_ROOT)/spectro/desi_spectro_calib/0.6.0

--- a/24.8
+++ b/24.8
@@ -102,7 +102,7 @@ module load desimeter/0.7.1
 module load simqso/v1.3.0
 module load speclite/v0.20
 module load QuasarNP/0.2.0
-module load specprod-db/1.1.0
+module load specprod-db/1.3.0
 module load fastspecfit/2.5.2
 
 


### PR DESCRIPTION
This PR sets specprod-db versions that are compatible with `guadalupe`, `iron` and `loa`.