### PR TITLE
new install_jupyter_kernel script for simplified DR installations

### DIFF
--- a/install_jupyter_kernel
+++ b/install_jupyter_kernel
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from __future__ import print_function
+
+import os
+import sys
+import glob
+import shutil
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(
+            description='Install a Jupyter kernel for a DESI software version and optionally data release environment')
+    parser.add_argument('-v', '--software-version', type=str, required=True,
+                        help='DESI software release version')
+    parser.add_argument('-r', '--data-release', type=str,
+                        help='DESI data release (default use DESI proprietary data)')
+    parser.add_argument('-o', '--outdir', type=str,
+                        help='Alternate output directory (default $HOME/.local/share/jupyter/kernels)')
+
+    args = parser.parse_args()
+
+    if 'DESIMODULES' in os.environ:
+        moduledir = os.environ['DESIMODULES']
+    elif 'NERSC_HOST' in os.environ:
+        moduledir = os.path.expandvars('/global/common/software/desi/$NERSC_HOST/desiconda/startup/modulefiles/desimodules')
+    else:
+        # TODO: in principle we could directly get the files from github without needing them on disk
+        print('ERROR: please set $DESIMODULES to the location of a https://github.com/desihub/desimodules clone')
+        return 1
+
+    release_modulefile = '{moduledir}/{version}'.format(moduledir=moduledir, version=args.software_version)
+    if not os.path.exists(release_modulefile):
+        print("ERROR: {} doesn't exist; check that dir for available versions".format(
+            release_modulefile))
+        return 1
+
+    if args.outdir is None:
+        outdir = os.path.expandvars('$HOME/.local/share/jupyter/kernels')
+    else:
+        outdir = args.outdir
+
+    kerneldir = '{outdir}/desi-{release}'.format(outdir=outdir, release=args.software_version)
+    if args.data_release is not None:
+        kerneldir += '-'+args.data_release
+
+    if os.path.exists(kerneldir):
+        print('ERROR: {kerneldir} already exists; not overwriting'.format(kerneldir=kerneldir))
+        sys.exit(1)
+    else:
+        os.makedirs(kerneldir)
+
+    # Select which shell to use
+    shell = os.path.basename(os.environ['SHELL'])
+    if shell in ('csh', 'tcsh'):
+        suffix = 'csh'
+    else:
+        suffix = 'sh'
+
+    # Create optional release arg for kernel.json file, including quotes and comma
+    if args.data_release is not None:
+        release_json_str = '"{release}",'.format(release=args.data_release)
+    else:
+        release_json_str = ''
+
+    display_name = 'DESI '+args.software_version
+    if args.data_release is not None:
+        display_name += ' '+args.data_release
+
+    # Create the kernel file
+    kernelfile = kerneldir+'/kernel.json'
+    with open(kernelfile, 'w') as fp:
+        fp.write("""{{
+ "language": "python",
+ "argv": [
+  "/global/common/software/desi/activate_desi_jupyter.{suffix}",
+  "{version}", {release_json_str}
+  "{{connection_file}}"
+ ],
+ "display_name": "{display_name}"
+}}
+""".format(suffix=suffix, version=args.software_version, release_json_str=release_json_str, display_name=display_name)
+    )
+
+    print('Wrote '+kernelfile)
+
+    #- Copy logo files
+    for filename in glob.glob(moduledir+'/logo-*.png'):
+        outfile = os.path.join(kerneldir, os.path.basename(filename))
+        shutil.copy(filename, outfile)
+
+if __name__ == '__main__':
+    sys.exit(main())
+

--- a/install_jupyter_kernel
+++ b/install_jupyter_kernel
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-from __future__ import print_function
-
 import os
 import sys
 import glob
@@ -43,6 +41,7 @@ def main():
 
     kerneldir = '{outdir}/desi-{release}'.format(outdir=outdir, release=args.software_version)
     if args.data_release is not None:
+        args.data_release = args.data_release.lower()  #- because desitree/dr1, desitree/edr are lowercase
         kerneldir += '-'+args.data_release
 
     if os.path.exists(kerneldir):
@@ -66,7 +65,7 @@ def main():
 
     display_name = 'DESI '+args.software_version
     if args.data_release is not None:
-        display_name += ' '+args.data_release
+        display_name += ' '+args.data_release.upper()  #- make release uppercase only for display_name
 
     # Create the kernel file
     kernelfile = kerneldir+'/kernel.json'

--- a/install_jupyter_kernel.sh
+++ b/install_jupyter_kernel.sh
@@ -7,6 +7,8 @@
 function usage() {
     local execName=$(basename $0)
     (
+    echo "DEPRECATED: this still works, but please use install_jupyter_kernel (without .sh) instead"
+    echo ""
     echo "${execName} [-h] [-v] RELEASE"
     echo ""
     echo "Install a Jupyter kernel definition."
@@ -28,6 +30,9 @@ while getopts hv argname; do
     esac
 done
 shift $((OPTIND - 1))
+
+echo "DEPRECATED: while this script still works, please use install_jupyter_kernel (without .sh) instead"
+
 #
 # Make sure release actually exists.
 #


### PR DESCRIPTION
This PR provides `install_jupyter_kernel` as a proposed replacement for `install_jupyter_kernel.sh`, with the primary motivation of dramatically simplifying our [current multi-step process](https://github.com/desihub/tutorials/blob/main/getting_started/installing_EDR_kernels_at_NERSC.md) for installing kernels for a data release environment, which also currently requires us to maintain pre-built kernel files for every software/datarelease combination.

The idea is that we would provide a link to this script in /global/common/software/desi/, and then the instructions would become:

For DESI users to install a kernel for a software release
```
/global/common/software/desi/install_jupyter_kernel -v 24.11
```

For non-DESI NERSC users *or* DESI users to install a kernel for a software release and switch to a data release environment
```
/global/common/software/desi/install_jupyter_kernel -v 24.11 -r dr1
```

Like the existing `install_jupyter_kernel.sh` script, it derives which activation script to use based upon $SHELL, and it generates the kernel file on the fly instead of requiring the user to pick a specific pre-built kernel.

The script is python 2.7 compatible, so it works with the ancient perlmutter default system python without requiring pre-loading a DESI-environment.  I've also tested it with python 3.10.14.  The script also has an --outdir option to write to somewhere other than $HOME/.local/share/jupyter/kernels for testing.

Example using my current checkout:
```
[perlmutter] $CFS/desi/users/sjbailey/code/desimodules/install_jupyter_kernel -v 23.1 -r edr
Wrote /global/homes/s/sjbailey/.local/share/jupyter/kernels/desi-23.1-edr/kernel.json
[perlmutter] cat /global/homes/s/sjbailey/.local/share/jupyter/kernels/desi-23.1-edr/kernel.json
{
 "language": "python",
 "argv": [
  "/global/common/software/desi/activate_desi_jupyter.sh",
  "23.1", "edr",
  "{connection_file}"
 ],
 "display_name": "DESI 23.1 edr"
}
```
Comparing to the existing pre-build edr-23.1 kernel:
```
[perlmutter] cat /global/common/software/desi/kernels/desi-edr-23.1-bash/kernel.json
{
 "language": "python",
 "argv": [
  "/global/common/software/desi/activate_desi_jupyter.sh",
  "23.1",
  "edr",
  "{connection_file}"
 ],
 "display_name": "DESI EDR 23.1"
}
```

Swapping the order of software release version vs. data release version was purposeful so that optional part of the name (the data release name) is at the end instead of in the middle.  Functionally they are the same.

For the moment the display name uses the lowercase "edr" or "dr1" to match the desitree module version that will be swapped under the hood, but I wouldn't be opposed to making the uppercase for the display name.  We might also consider forcing the `-r` option to lowercase since that is what we use for desitree, so that this would also work even with the "incorrect" capitalization:
```
install_jupyter_kernel -v 24.11 -r DR1
```
